### PR TITLE
Add Rom Targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ extract: $(addsuffix /,${rom_dirs})
 # Calls for the pret repo to check for updates, then checks if the .cias need to be updated
 .PHONY: pretupdate
 pretupdate:
-	$(MAKE) -C ${repo_path} $(subst poke,,${rom_names}) $(subst poke,,$(addsuffix _vc, ${rom_names}))
+	$(MAKE) -C ${repo_path} $(rom_targets)
 
 # Tides up poke-cia
 .PHONY: tidy

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Modify this new `config.mk` file using a text editor of your choice.
   
   (Relative paths must be relative to the `poke-cia` directory. `../` means the directory above the poke-cia directory.)
   
-  - Finally in that same file, you will need to set the `rom_targets` variable. This variable is used by poke-cia to run the appropriate `make` command build targets on the repository specified in the `repo_path` variable. 
+- Finally in that same file, you will need to set the `rom_targets` variable. This variable is used by poke-cia to run the appropriate `make` command build targets on the repository specified in the `repo_path` variable. 
 
-```makefile
-repo_targets := red red_vc blue blue_vc
-```
+  ```makefile
+  repo_targets := red red_vc blue blue_vc
+  ```
 
 Copy and rename your original dumped .cia files to `<build_name>.orig.cia`, where `<build_name>` is one of the names you put in `rom_names`.
 For example, for Pokémon Crystal, it should be `pokecrystal11.orig.cia`.

--- a/README.md
+++ b/README.md
@@ -53,10 +53,16 @@ Modify this new `config.mk` file using a text editor of your choice.
 - Still in that same file, you must also set the `repo_path` variable to point to the repository containing the ROMs: (The default `repo_path` setting assumes you are cloning into the pret repo)
   
   ```makefile
-  repo_path  := ../
+  repo_path := ../
   ```
   
   (Relative paths must be relative to the `poke-cia` directory. `../` means the directory above the poke-cia directory.)
+  
+  - Finally in that same file, you will need to set the `rom_targets` variable. This variable is used by poke-cia to run the appropriate `make` command build targets on the repository specified in the `repo_path` variable. 
+
+```makefile
+repo_targets := red red_vc blue blue_vc
+```
 
 Copy and rename your original dumped .cia files to `<build_name>.orig.cia`, where `<build_name>` is one of the names you put in `rom_names`.
 For example, for Pokémon Crystal, it should be `pokecrystal11.orig.cia`.

--- a/config.mk.template
+++ b/config.mk.template
@@ -1,13 +1,22 @@
-# Uncomment one of the following lines depending on your repo, or write your own!
-#rom_names := pokered pokeblue
-#rom_names := pokeyellow
-#rom_names := pokegold pokesilver
-#rom_names := pokecrystal11
-#rom_names := my_awesome_hack
+# Define repo_path, rom_names, and rom_targets for your particular project!
+# The commented ones below are examples.
 
-# Write the path to the repo here. Here are some examples. Default assumes that
-# you cloned poke-cia inside the pret repo. ../ means the directory above this one:
-repo_path   := ../
-#repo_path  := ../pokered
-#repo_path  := /drives/c/Users/ISSOtm/Documents/pokecrystal
-#repo_path  := /d/vulcandth/pkmn/pokedarkgold
+#repo_path := ../
+#rom_names := pokered pokeblue
+#rom_targets := red red_vc blue blue_vc
+
+#repo_path := ../pokecrystal
+#rom_names := pokecrystal
+#rom_targets := crystal11 crystal11_vc
+
+#repo_path := /drives/c/Users/ISSOtm/Desktop/pokegold
+#rom_names := pokegold
+#rom_targets := gold gold_vc
+
+#repo_path := ~/polishedcrystal
+#rom_names := polishedcrystal-3.0.0-beta
+#rom_targets := crystal vc
+
+#repo_path := /d/vulcandth/pkmn/my_awesome_hack
+#rom_names := my_awesome_hack
+#rom_targets := hack hack_vc

--- a/config.mk.template
+++ b/config.mk.template
@@ -1,22 +1,22 @@
 # Define repo_path, rom_names, and rom_targets for your particular project!
 # The commented ones below are examples.
 
-#repo_path := ../
-#rom_names := pokered pokeblue
+#repo_path   := ../
+#rom_names   := pokered pokeblue
 #rom_targets := red red_vc blue blue_vc
 
-#repo_path := ../pokecrystal
-#rom_names := pokecrystal
+#repo_path   := ../pokecrystal
+#rom_names   := pokecrystal
 #rom_targets := crystal11 crystal11_vc
 
-#repo_path := /drives/c/Users/ISSOtm/Desktop/pokegold
-#rom_names := pokegold
+#repo_path   := /drives/c/Users/ISSOtm/Desktop/pokegold
+#rom_names   := pokegold
 #rom_targets := gold gold_vc
 
-#repo_path := ~/polishedcrystal
-#rom_names := polishedcrystal-3.0.0-beta
+#repo_path   := ~/polishedcrystal
+#rom_names   := polishedcrystal-3.0.0-beta
 #rom_targets := crystal vc
 
-#repo_path := /d/vulcandth/pkmn/my_awesome_hack
-#rom_names := my_awesome_hack
+#repo_path   := /d/vulcandth/pkmn/my_awesome_hack
+#rom_names   := my_awesome_hack
 #rom_targets := hack hack_vc


### PR DESCRIPTION
This PR implements a rom_targets variable that is useful when the user is using a Romhack that requires unique build targets. Polished Crystal is an example of this.

Resolves #7 